### PR TITLE
Update deprecated implode() call to ensure php8 compatibility

### DIFF
--- a/format.php
+++ b/format.php
@@ -52,7 +52,7 @@ class qformat_canvas extends qformat_based_on_xml {
      */
     public function readquestions($lines) {
         question_bank::get_qtype('multianswer'); // Ensure the multianswer code is loaded.
-        $text = implode($lines, ' ');
+        $text = implode(' ', $lines);
         unset($lines);
         // This converts xml to big nasty data structure,
         // the 0 means keep white space as it is.


### PR DESCRIPTION
I understand the plugin is no longer maintained. Just leaving this PR here in case anyone's using it with Moodle 4 as I did.
Closes #9 